### PR TITLE
Fix PCH include and wide-char buffer conversion

### DIFF
--- a/PoringProtect/pch.h
+++ b/PoringProtect/pch.h
@@ -1,2 +1,4 @@
 #pragma once
 
+#include "framework.h"
+

--- a/PoringProtect/ragnaph.cpp
+++ b/PoringProtect/ragnaph.cpp
@@ -82,7 +82,10 @@ static bool is_clientinfoA(LPCSTR name) {
         return false;
     }
     std::wstring wide(static_cast<std::size_t>(len), L'\0');
-    MultiByteToWideChar(CP_ACP, 0, name, -1, wide.data(), len);
+    // MultiByteToWideChar requires a writable buffer for the destination.
+    // In pre-C++17 standards, std::wstring::data() returns a const pointer,
+    // so use &wide[0] to obtain a modifiable buffer.
+    MultiByteToWideChar(CP_ACP, 0, name, -1, &wide[0], len);
     if (!wide.empty() && wide.back() == L'\0') {
         wide.pop_back();
     }


### PR DESCRIPTION
## Summary
- include framework headers in pch.h to satisfy precompiled header build
- fix MultiByteToWideChar call to use writable buffer when converting narrow clientinfo paths

## Testing
- `g++ -std=c++17 PoringProtect/dllmain.cpp PoringProtect/ragnaph.cpp PoringProtect/pch.cpp -I PoringProtect -o PoringProtect/out.exe` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a59730c288832e82827d4707d1cd87