### PR TITLE
Embed clientinfo via hooks

### DIFF
--- a/PoringProtect/clientinfo.rc
+++ b/PoringProtect/clientinfo.rc
@@ -1,0 +1,3 @@
+#include "resource1.h"
+
+IDR_CLIENTINFO RCDATA "clientinfo.xml"

--- a/PoringProtect/clientinfo.xml
+++ b/PoringProtect/clientinfo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="euc-kr" ?>
+<clientinfo>
+   <desc>Ragnarok Client Information</desc>
+   <servicetype>korea</servicetype>
+   <servertype>primary</servertype>
+   <connection>
+      <display>RagnaPH</display>
+            <address>server.ragna.ph</address>
+            <port>6901</port>
+            <version>55</version>
+            <langtype>11</langtype>
+    <registrationweb>https://ragna.ph/?module=account&action=create</registrationweb>
+        <loading>
+            <image>loading00.jpg</image>
+            <image>loading01.jpg</image>
+            <image>loading02.jpg</image>
+            <image>loading03.jpg</image>
+            <image>loading04.jpg</image>
+        </loading>
+        <aid>
+            <admin>2000000</admin>
+            <admin>2000001</admin>
+            <admin>2000002</admin>
+            <admin>2000003</admin>
+            <admin>2000004</admin>
+            <admin>2000005</admin>
+        </aid>
+      </connection>
+</clientinfo>

--- a/PoringProtect/clientinfo_hook.cpp
+++ b/PoringProtect/clientinfo_hook.cpp
@@ -1,0 +1,92 @@
+#include <windows.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cstring>
+#include "MinHook.h"
+#include "resource1.h" // defines IDR_CLIENTINFO
+
+// Global buffer for embedded clientinfo.xml
+static std::vector<char> g_clientinfo;
+static const HANDLE kFakeHandle = (HANDLE)0x1234;
+static size_t g_offset = 0;
+
+// Load RCDATA resource into g_clientinfo
+static bool load_rcdata(HMODULE hModule, int resId)
+{
+    HRSRC hRes = FindResourceW(hModule, MAKEINTRESOURCEW(resId), RT_RCDATA);
+    if (!hRes) return false;
+    HGLOBAL hData = LoadResource(hModule, hRes);
+    if (!hData) return false;
+    DWORD size = SizeofResource(hModule, hRes);
+    const char* ptr = static_cast<const char*>(LockResource(hData));
+    g_clientinfo.assign(ptr, ptr + size);
+    return true;
+}
+
+// Original function pointers
+static HANDLE (WINAPI* fpCreateFileW)(LPCWSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE) = nullptr;
+static BOOL   (WINAPI* fpReadFile)(HANDLE, LPVOID, DWORD, LPDWORD, LPOVERLAPPED) = nullptr;
+
+// Helper to check for clientinfo.xml in path
+static bool is_clientinfo(LPCWSTR path)
+{
+    if (!path) return false;
+    std::wstring s(path);
+    std::transform(s.begin(), s.end(), s.begin(), ::towlower);
+    return s.find(L"clientinfo.xml") != std::wstring::npos;
+}
+
+// Hooked CreateFileW
+static HANDLE WINAPI HookCreateFileW(LPCWSTR name, DWORD access, DWORD share,
+    LPSECURITY_ATTRIBUTES sa, DWORD disp, DWORD flags, HANDLE tmpl)
+{
+    if (is_clientinfo(name)) {
+        g_offset = 0;
+        return kFakeHandle;
+    }
+    return fpCreateFileW(name, access, share, sa, disp, flags, tmpl);
+}
+
+// Hooked ReadFile
+static BOOL WINAPI HookReadFile(HANDLE hFile, LPVOID buffer, DWORD toRead,
+    LPDWORD read, LPOVERLAPPED overlapped)
+{
+    if (hFile == kFakeHandle) {
+        if (read) {
+            DWORD remain = static_cast<DWORD>(g_clientinfo.size() - g_offset);
+            DWORD copy = min(toRead, remain);
+            if (copy && buffer)
+                std::memcpy(buffer, g_clientinfo.data() + g_offset, copy);
+            g_offset += copy;
+            *read = copy;
+        }
+        return TRUE;
+    }
+    return fpReadFile(hFile, buffer, toRead, read, overlapped);
+}
+
+bool InitClientInfoHooks(HMODULE module)
+{
+    if (!load_rcdata(module, IDR_CLIENTINFO))
+        return false;
+    if (MH_Initialize() != MH_OK)
+        return false;
+    if (MH_CreateHook(&CreateFileW, &HookCreateFileW, reinterpret_cast<LPVOID*>(&fpCreateFileW)) != MH_OK)
+        return false;
+    if (MH_CreateHook(&ReadFile, &HookReadFile, reinterpret_cast<LPVOID*>(&fpReadFile)) != MH_OK)
+        return false;
+    if (MH_EnableHook(&CreateFileW) != MH_OK)
+        return false;
+    if (MH_EnableHook(&ReadFile) != MH_OK)
+        return false;
+    return true;
+}
+
+void UninitClientInfoHooks()
+{
+    MH_DisableHook(&CreateFileW);
+    MH_DisableHook(&ReadFile);
+    MH_Uninitialize();
+}
+

--- a/PoringProtect/clientinfo_hook.h
+++ b/PoringProtect/clientinfo_hook.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <windows.h>
+
+// Initialize hooks that serve embedded clientinfo.xml.
+// Returns true on success.
+bool InitClientInfoHooks(HMODULE module);
+
+// Remove any installed hooks.
+void UninitClientInfoHooks();

--- a/PoringProtect/dllmain.cpp
+++ b/PoringProtect/dllmain.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <shlwapi.h>
 #pragma comment(lib, "Shlwapi.lib")
+#include "clientinfo_hook.h"
 
 // --- Configuration ---
 static const wchar_t* bannedExes[] = {
@@ -58,11 +59,14 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
 {
     if (reason == DLL_PROCESS_ATTACH) {
         DisableThreadLibraryCalls(hModule);
+        InitClientInfoHooks(hModule);
 
         // Directly start anti-cheat thread, no opensetup checks
         HANDLE hThread = CreateThread(NULL, 0, ProtectionThread, NULL, 0, NULL);
         if (!hThread) return FALSE;
         CloseHandle(hThread);
+    } else if (reason == DLL_PROCESS_DETACH) {
+        UninitClientInfoHooks();
     }
     return TRUE;
 }

--- a/PoringProtect/resource1.h
+++ b/PoringProtect/resource1.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define IDB_PNG1        101
+#define IDR_CLIENTINFO  102

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# PoringProtect
+
+This project builds a Windows DLL that performs simple anti-cheat checks and now
+also embeds `clientinfo.xml` into the binary. When a game attempts to open
+`clientinfo.xml`, the DLL serves the embedded copy instead of reading from disk.
+
+## Building
+
+1. Build as a Win32/x86 DLL with Visual Studio.
+2. Add the [MinHook](https://github.com/TsudaKageyu/minhook) sources to the
+   project.
+3. Ensure `clientinfo.xml` is included in the project so the `.rc` files compile
+   it as `IDR_CLIENTINFO`.
+
+Since `RagnaPH.exe` already loads `poringprotect.dll`, no extra injection is
+required. To test, remove `clientinfo.xml` from disk and confirm that login and
+server selection still work.


### PR DESCRIPTION
## Summary
- Embed `clientinfo.xml` as an RCDATA resource and serve it via MinHook
- Hook `CreateFileW`/`ReadFile` so the game loads the embedded client info
- Document build steps and resource setup
- Expand embedded `clientinfo.xml` with RagnaPH server configuration

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5ab9e59e4832eaea05d47f42351ae