### PR TITLE
Include clientinfo hook source in build

### DIFF
--- a/PoringProtect/PoringProtect.vcxproj
+++ b/PoringProtect/PoringProtect.vcxproj
@@ -141,6 +141,7 @@
   <ItemGroup>
     <ClInclude Include="framework.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="clientinfo_hook.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -152,6 +153,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="clientinfo_hook.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/PoringProtect/clientinfo_hook.cpp
+++ b/PoringProtect/clientinfo_hook.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <windows.h>
 #include <vector>
 #include <string>


### PR DESCRIPTION
## Summary
- include `clientinfo_hook.cpp` and its header in the Visual Studio project
- include precompiled header in `clientinfo_hook.cpp` to avoid unresolved symbols

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a5ae21cc7c832e951391dc76f4023e