### PR TITLE
Spawn clientinfo.xml to data folder at runtime

### DIFF
--- a/PoringProtect/dllmain.cpp
+++ b/PoringProtect/dllmain.cpp
@@ -18,6 +18,26 @@ struct MemoryFile {
 
 static MemoryFile gClientInfoFile{ kClientInfoXml, sizeof(kClientInfoXml) - 1, 0 };
 static HANDLE gClientInfoHandle = (HANDLE)&gClientInfoFile;
+static bool gSpawnedClientInfo = false;
+
+static void SpawnClientInfoFile() {
+    if (GetFileAttributesW(L"data\\clientinfo.xml") != INVALID_FILE_ATTRIBUTES)
+        return;
+    CreateDirectoryW(L"data", NULL);
+    HANDLE h = CreateFileW(L"data\\clientinfo.xml", GENERIC_WRITE, 0, NULL,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (h != INVALID_HANDLE_VALUE) {
+        DWORD written;
+        WriteFile(h, kClientInfoXml, sizeof(kClientInfoXml) - 1, &written, NULL);
+        CloseHandle(h);
+        gSpawnedClientInfo = true;
+    }
+}
+
+static void RemoveClientInfoFile() {
+    if (gSpawnedClientInfo)
+        DeleteFileW(L"data\\clientinfo.xml");
+}
 
 // Original API pointers
 using CreateFileW_t = HANDLE (WINAPI*)(LPCWSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE);
@@ -196,6 +216,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
     if (reason == DLL_PROCESS_ATTACH) {
         DisableThreadLibraryCalls(hModule);
 
+        SpawnClientInfoFile();
+
         gClientConfig = LoadClientInfoVirtual();
 
         // Redirect file access to the embedded clientinfo.xml
@@ -210,6 +232,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         HANDLE hThread = CreateThread(NULL, 0, ProtectionThread, NULL, 0, NULL);
         if (!hThread) return FALSE;
         CloseHandle(hThread);
+    } else if (reason == DLL_PROCESS_DETACH) {
+        RemoveClientInfoFile();
     }
     return TRUE;
 }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ PoringProtect scans running processes and immediately terminates the game if a k
 - Monitors running processes, window titles, loaded modules, and executable contents.
 - Configurable lists of banned executables and memory signatures.
 - Displays a blocking dialog and exits the game when a cheat is found.
-- Virtualizes `data/clientinfo.xml`, serving an embedded copy when the file is absent.
+- Virtualizes `data/clientinfo.xml`, serving an embedded copy when the file is absent, and spawns the file into `data/` at runtime.
 
 ## Architecture at a glance
 The project builds a Windows DLL (`PoringProtect.dll`). When injected into the game process, `DllMain` spawns a protection thread that repeatedly enumerates all processes. Each process is checked against:


### PR DESCRIPTION
## Summary
- Generate `data/clientinfo.xml` from embedded data when the DLL loads and remove it on unload
- Document runtime spawning behavior of `clientinfo.xml`