### PR TITLE
Fix GDI+ build errors

### DIFF
--- a/PoringProtect/PoringProtect.vcxproj
+++ b/PoringProtect/PoringProtect.vcxproj
@@ -71,14 +71,15 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;PORINGPROTECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-    </ClCompile>
+      <ClCompile>
+        <WarningLevel>Level3</WarningLevel>
+        <SDLCheck>true</SDLCheck>
+        <PreprocessorDefinitions>WIN32;_DEBUG;PORINGPROTECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <ConformanceMode>true</ConformanceMode>
+        <PrecompiledHeader>Use</PrecompiledHeader>
+        <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+        <LanguageStandard>stdcpp17</LanguageStandard>
+      </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -86,16 +87,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;PORINGPROTECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-    </ClCompile>
+      <ClCompile>
+        <WarningLevel>Level3</WarningLevel>
+        <FunctionLevelLinking>true</FunctionLevelLinking>
+        <IntrinsicFunctions>true</IntrinsicFunctions>
+        <SDLCheck>true</SDLCheck>
+        <PreprocessorDefinitions>WIN32;NDEBUG;PORINGPROTECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <ConformanceMode>true</ConformanceMode>
+        <PrecompiledHeader>Use</PrecompiledHeader>
+        <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+        <LanguageStandard>stdcpp17</LanguageStandard>
+      </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -105,14 +107,15 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;PORINGPROTECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-    </ClCompile>
+      <ClCompile>
+        <WarningLevel>Level3</WarningLevel>
+        <SDLCheck>true</SDLCheck>
+        <PreprocessorDefinitions>_DEBUG;PORINGPROTECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <ConformanceMode>true</ConformanceMode>
+        <PrecompiledHeader>Use</PrecompiledHeader>
+        <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+        <LanguageStandard>stdcpp17</LanguageStandard>
+      </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -120,16 +123,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;PORINGPROTECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-    </ClCompile>
+      <ClCompile>
+        <WarningLevel>Level3</WarningLevel>
+        <FunctionLevelLinking>true</FunctionLevelLinking>
+        <IntrinsicFunctions>true</IntrinsicFunctions>
+        <SDLCheck>true</SDLCheck>
+        <PreprocessorDefinitions>NDEBUG;PORINGPROTECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <ConformanceMode>true</ConformanceMode>
+        <PrecompiledHeader>Use</PrecompiledHeader>
+        <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+        <LanguageStandard>stdcpp17</LanguageStandard>
+      </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/PoringProtect/dllmain.cpp
+++ b/PoringProtect/dllmain.cpp
@@ -174,7 +174,7 @@ static const char* bannedMemPatterns[] = {
 
 struct ClientConfig {
     std::string address;
-    int port;
+    int port = 0;
 };
 
 static ClientConfig LoadClientInfoVirtual() {

--- a/PoringProtect/popup.cpp
+++ b/PoringProtect/popup.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include <windows.h>
 #include <gdiplus.h>
 #pragma comment(lib, "gdiplus.lib")
 


### PR DESCRIPTION
## Summary
- include Windows headers before GDI+ to expose META constants
- default-initialize ClientConfig port and enable C++17