### PR TITLE
Fix ambiguous FillRectangle calls in UI

### DIFF
--- a/PoringProtect/ui.cpp
+++ b/PoringProtect/ui.cpp
@@ -76,8 +76,8 @@ static LRESULT CALLBACK LoaderProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
         g.SetSmoothingMode(SmoothingModeAntiAlias);
         RECT rc; GetClientRect(hwnd, &rc);
         SolidBrush bg(Color(0xFF, 0x2B, 0x2B, 0x2B));
-        g.FillRectangle(&bg, rc.left, rc.top,
-            rc.right - rc.left, rc.bottom - rc.top);
+        Rect r(rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top);
+        g.FillRectangle(&bg, r);
 
         FontFamily ff(L"Segoe UI");
         Font title(&ff, 14, FontStyleBold, UnitPoint);
@@ -185,8 +185,8 @@ static LRESULT CALLBACK ControlProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM l
         Graphics g(hdc); g.SetSmoothingMode(SmoothingModeAntiAlias);
         RECT rc; GetClientRect(hwnd, &rc);
         SolidBrush bg(Color(0xFF, 0x2B, 0x2B, 0x2B));
-        g.FillRectangle(&bg, rc.left, rc.top,
-            rc.right - rc.left, rc.bottom - rc.top);
+        Rect r(rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top);
+        g.FillRectangle(&bg, r);
 
         FontFamily ff(L"Segoe UI");
         Font title(&ff, 14, FontStyleBold, UnitPoint);


### PR DESCRIPTION
## Summary
- Avoid GDI+ overload ambiguity by supplying a Rect to `Graphics::FillRectangle`
- Apply fix across loader and control window paint handlers