### PR TITLE
Ensure SafePlay logo displays in startup loader

### DIFF
--- a/SafePlay/SafePlay.vcxproj
+++ b/SafePlay/SafePlay.vcxproj
@@ -142,6 +142,7 @@
     <ClInclude Include="framework.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="clientinfo.h" />
+    <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -153,6 +154,9 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="resource.rc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\assets\SafePlay.png">

--- a/SafePlay/SafePlay.vcxproj.filters
+++ b/SafePlay/SafePlay.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClInclude Include="clientinfo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -32,5 +35,8 @@
     <ClCompile Include="pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ResourceCompile Include="resource.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -12,7 +12,10 @@
 #pragma comment(lib, "Msimg32.lib")
 #include <gdiplus.h>
 #pragma comment(lib, "Gdiplus.lib")
+#include <objidl.h>
+#pragma comment(lib, "Ole32.lib")
 #include "clientinfo.h"
+#include "resource.h"
 
 // --- Virtual clientinfo.xml handling ---
 struct MemoryFile {
@@ -63,6 +66,30 @@ static Gdiplus::Bitmap* LoadSafePlayLogo() {
             auto* bmp = Gdiplus::Bitmap::FromFile(cand[i]);
             if (bmp && bmp->GetLastStatus() == Gdiplus::Ok) return bmp;
             delete bmp;
+        }
+    }
+    // Fallback: load from embedded PNG resource
+    HRSRC hRes = FindResourceW(g_hModule, MAKEINTRESOURCEW(IDB_SAFEPLAY_LOGO), L"PNG");
+    if (hRes) {
+        HGLOBAL hData = LoadResource(g_hModule, hRes);
+        if (hData) {
+            void* pData = LockResource(hData);
+            DWORD size = SizeofResource(g_hModule, hRes);
+            if (pData && size) {
+                HGLOBAL hBuffer = GlobalAlloc(GMEM_MOVEABLE, size);
+                if (hBuffer) {
+                    void* pBuffer = GlobalLock(hBuffer);
+                    memcpy(pBuffer, pData, size);
+                    GlobalUnlock(hBuffer);
+                    IStream* pStream = nullptr;
+                    if (SUCCEEDED(CreateStreamOnHGlobal(hBuffer, TRUE, &pStream))) {
+                        auto* bmp = Gdiplus::Bitmap::FromStream(pStream);
+                        pStream->Release();
+                        if (bmp && bmp->GetLastStatus() == Gdiplus::Ok) return bmp;
+                        delete bmp;
+                    }
+                }
+            }
         }
     }
 

--- a/SafePlay/resource.h
+++ b/SafePlay/resource.h
@@ -1,0 +1,2 @@
+#pragma once
+#define IDB_SAFEPLAY_LOGO 101

--- a/SafePlay/resource.rc
+++ b/SafePlay/resource.rc
@@ -1,0 +1,3 @@
+#include "resource.h"
+
+IDB_SAFEPLAY_LOGO PNG "..\\assets\\SafePlay.png"


### PR DESCRIPTION
## Summary
- Embed SafePlay.png as a resource and load it if file lookup fails
- Added resource files and project references for SafePlay logo