### PR TITLE
Launch game with SafePlay.dll as working directory

### DIFF
--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -558,7 +558,22 @@ static DWORD WINAPI LoadingPopupThread(LPVOID) {
 
 static DWORD WINAPI LaunchGameThread(LPVOID) {
     WaitForSingleObject(g_hProgressDone, INFINITE);
-    ShellExecuteW(NULL, L"open", L"RagnaPH.exe", NULL, NULL, SW_SHOWNORMAL);
+
+    wchar_t base[MAX_PATH];
+    GetModuleFileNameW(g_hModule, base, MAX_PATH);
+    PathRemoveFileSpecW(base);
+
+    SHELLEXECUTEINFOW sei{};
+    sei.cbSize = sizeof(sei);
+    sei.fMask = SEE_MASK_NOCLOSEPROCESS;
+    sei.lpFile = L"RagnaPH.exe";
+    sei.nShow = SW_SHOWNORMAL;
+    sei.lpDirectory = base;
+
+    if (ShellExecuteExW(&sei)) {
+        WaitForSingleObject(sei.hProcess, INFINITE);
+        CloseHandle(sei.hProcess);
+    }
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Launch game from the directory containing SafePlay.dll
- Use ShellExecuteExW with SEE_MASK_NOCLOSEPROCESS to optionally wait on the child process