### PR TITLE
Initialize ClientConfig port to zero

### DIFF
--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -234,7 +234,7 @@ static const char* bannedMemPatterns[] = {
 
 struct ClientConfig {
     std::string address;
-    int port;
+    int port = 0;
 };
 
 static ClientConfig LoadClientInfoVirtual() {


### PR DESCRIPTION
## Summary
- Default-initialize `ClientConfig::port` to `0` to ensure predictable values.