### PR TITLE
Ensure progress event auto-resets for each launch

### DIFF
--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -572,7 +572,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         Gdiplus::GdiplusStartupInput gdiplusStartupInput;
         Gdiplus::GdiplusStartup(&gGdiplusToken, &gdiplusStartupInput, NULL);
 
-        g_hProgressDone = CreateEvent(NULL, TRUE, FALSE, NULL);
+        g_hProgressDone = CreateEvent(NULL, FALSE, FALSE, NULL);
         // Show loading popup without blocking game startup
         HANDLE hPopup = CreateThread(NULL, 0, LoadingPopupThread, NULL, 0, NULL);
 


### PR DESCRIPTION
## Summary
- Create progress synchronization event as auto-reset so each game launch waits for the loading popup to finish

## Testing
- `x86_64-w64-mingw32-g++ -shared SafePlay/dllmain.cpp SafePlay/pch.cpp -o SafePlay.dll -municode -lgdiplus -lcomctl32 -lshell32 -lshlwapi -lmsimg32 -lole32` *(fails: ‘min’ was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1f9b25d8832e87552791e9ab029d