### PR TITLE
Use launcher token for startup verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ game process, provides a trusted client configuration, and continuously scans th
 * **Embedded configuration** – `clientinfo.xml` is stored in the DLL and is served from memory so the game always connects to
   the approved server settings.
 * **Integrity check** – the library verifies that `Data.ini` contains the expected resource listing before starting.
+* **Launcher enforcement** – `RagnaPH.exe` only starts when launched with a token provided by `RagnaPH Launcher.exe`, preventing manual execution.
 * **API hooking** – kernel32 file APIs are patched via the Import Address Table to redirect file access to the in-memory
   configuration and to hide the virtual file handle.
 * **Background protection thread** – every five seconds the DLL enumerates running processes and evaluates them against several
@@ -40,6 +41,7 @@ game process, provides a trusted client configuration, and continuously scans th
 * Modify `SafePlay/clientinfo.h` to change the embedded server address, port, or other client settings.
 * `Data.ini` must have `data.grf` as its first entry – the DLL validates this file before enabling protection.
 * Extend the banned executable, window, module, or memory signature lists in `SafePlay/dllmain.cpp` to detect additional tools.
+* The launcher must set environment variable `RAGNAPH_LAUNCHED=1` or pass `--from-launcher` when starting `RagnaPH.exe`.
 
 ## Roadmap
 - Cross-game compatibility

--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -1,6 +1,5 @@
 ﻿#include "pch.h"
 #include <windows.h>
-#include <tlhelp32.h>
 #include <vector>
 #include <string>
 #include <cstring>
@@ -265,6 +264,31 @@ static bool VerifyDataIni() {
     if (GetPrivateProfileStringA("Data", "0", "", buf, sizeof(buf), path) == 0 || _stricmp(buf, "data.grf") != 0)
         return false;
     return true;
+}
+
+// Determine if the current process was launched by the official launcher
+// The launcher sets either an environment variable or a command-line flag
+// to prove that it invoked the game.
+static bool IsLaunchedFromLauncher() {
+    // Check for environment variable token
+    wchar_t envBuf[2];
+    if (GetEnvironmentVariableW(L"RAGNAPH_LAUNCHED", envBuf, _countof(envBuf)) > 0)
+        return true;
+
+    // Check for command-line flag
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (argv) {
+        for (int i = 0; i < argc; ++i) {
+            if (_wcsicmp(argv[i], L"--from-launcher") == 0) {
+                LocalFree(argv);
+                return true;
+            }
+        }
+        LocalFree(argv);
+    }
+
+    return false;
 }
 
 // Function prototypes
@@ -566,6 +590,14 @@ static DWORD WINAPI LaunchGameThread(LPVOID) {
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
 {
     if (reason == DLL_PROCESS_ATTACH) {
+        wchar_t processPath[MAX_PATH];
+        GetModuleFileNameW(NULL, processPath, MAX_PATH);
+        const wchar_t* processName = PathFindFileNameW(processPath);
+        if (_wcsicmp(processName, L"RagnaPH.exe") == 0 && !IsLaunchedFromLauncher()) {
+            MessageBoxW(NULL, L"Please start the game via RagnaPH Launcher.", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
+            ExitProcess(0);
+        }
+
         g_hModule = hModule;
         DisableThreadLibraryCalls(hModule);
 
@@ -576,9 +608,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         // Show loading popup without blocking game startup
         HANDLE hPopup = CreateThread(NULL, 0, LoadingPopupThread, NULL, 0, NULL);
 
-        wchar_t processPath[MAX_PATH];
-        GetModuleFileNameW(NULL, processPath, MAX_PATH);
-        const wchar_t* processName = PathFindFileNameW(processPath);
         // Prevent infinite self-launching when the DLL is injected into the game executable itself
         if (_wcsicmp(processName, L"RagnaPH.exe") != 0) {
             HANDLE hLaunch = CreateThread(NULL, 0, LaunchGameThread, NULL, 0, NULL);


### PR DESCRIPTION
## Summary
- Replace fragile parent-process check with token-based `IsLaunchedFromLauncher` that looks for a special environment variable or `--from-launcher` flag.
- Document token requirement so RagnaPH.exe only runs when launched by the official launcher.

## Testing
- `msbuild SafePlay.sln` *(fails: command not found)*
- `dotnet build SafePlay.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad43df3d34832ead71285e0db6d568