### PR TITLE
Fix RagnaPH launcher detection before game process validation

### DIFF
--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -623,16 +623,17 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         wchar_t processPath[MAX_PATH];
         GetModuleFileNameW(NULL, processPath, MAX_PATH);
         const wchar_t* processName = PathFindFileNameW(processPath);
-        // If we are the game process, ensure it was launched by the official launcher
-        if (_wcsicmp(processName, L"RagnaPH.exe") == 0) {
+        // Handle launcher and game processes separately to avoid accidental self-launching
+        if (_wcsicmp(processName, L"RagnaPH Launcher.exe") == 0) {
+            // When injected into the official launcher, start the game after the popup
+            HANDLE hLaunch = CreateThread(NULL, 0, LaunchGameThread, NULL, 0, NULL);
+            if (hLaunch) CloseHandle(hLaunch);
+        } else if (_wcsicmp(processName, L"RagnaPH.exe") == 0) {
+            // If we are the game process, ensure it was launched by the official launcher
             if (!IsLaunchedFromLauncher()) {
                 CreateThread(NULL, 0, ShowLauncherErrorAndExit, NULL, 0, NULL);
                 return TRUE;
             }
-        } else {
-            // Prevent infinite self-launching when injected into the launcher
-            HANDLE hLaunch = CreateThread(NULL, 0, LaunchGameThread, NULL, 0, NULL);
-            if (hLaunch) CloseHandle(hLaunch);
         }
 
         Gdiplus::GdiplusStartupInput gdiplusStartupInput;


### PR DESCRIPTION
## Summary
- Separate logic for `RagnaPH Launcher.exe` and `RagnaPH.exe`
- Launch game only when DLL is loaded in the official launcher
- Verify game process is started from the launcher and show error otherwise

## Testing
- `g++ -std=c++17 -c SafePlay/dllmain.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6581dd20832e807693c299cf2393