### PR TITLE
Allow launching additional clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ game process, provides a trusted client configuration, and continuously scans th
   - static memory signatures (e.g. `4RTools`)
 * **User feedback** – during startup a small non-blocking popup with a progress bar is displayed.
 * When any banned tool is detected a message box identifies the offending program and the game is terminated.
+* **Multi-client friendly** – once a game instance is started through the official launcher, additional clients may be launched even after the launcher closes.
 
 ## Building
 1. Clone the repository:

--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -327,6 +327,26 @@ static bool IsLaunchedFromLauncher() {
         pid = parentPid;
     }
 
+    // If no launcher is found in the ancestry, allow the game to start when
+    // another instance of RagnaPH.exe is already running. This enables
+    // launching additional clients after the first one has been started via
+    // the official launcher, even if the launcher has exited.
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snap != INVALID_HANDLE_VALUE) {
+        PROCESSENTRY32W pe{};
+        pe.dwSize = sizeof(pe);
+        if (Process32FirstW(snap, &pe)) {
+            do {
+                if (_wcsicmp(pe.szExeFile, L"RagnaPH.exe") == 0 &&
+                    pe.th32ProcessID != GetCurrentProcessId()) {
+                    CloseHandle(snap);
+                    return true;
+                }
+            } while (Process32NextW(snap, &pe));
+        }
+        CloseHandle(snap);
+    }
+
     return false;
 }
 


### PR DESCRIPTION
## Summary
- Allow game to start additional clients when another RagnaPH.exe instance exists
- Document multi-client support in README

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -c SafePlay/dllmain.cpp -o /tmp/dllmain.o` *(fails: ‘min’ was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6fb4a104832ebbde77fd146590c6