### PR TITLE
Hold launcher until SafePlay initializes

### DIFF
--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -50,6 +50,7 @@ static GetFileAttributesA_t RealGetFileAttributesA;
 static ULONG_PTR gGdiplusToken;
 HMODULE g_hModule = nullptr;
 static HANDLE g_hProgressDone = NULL;
+static const wchar_t* kReadyEventName = L"SafePlayReady";
 
 static Gdiplus::Bitmap* LoadSafePlayLogo() {
     wchar_t base[MAX_PATH];
@@ -652,7 +653,12 @@ static DWORD WINAPI LoadingPopupThread(LPVOID) {
 
 static DWORD WINAPI LaunchGameThread(LPVOID) {
     WaitForSingleObject(g_hProgressDone, INFINITE);
+    HANDLE hReady = CreateEventW(NULL, TRUE, FALSE, kReadyEventName);
     ShellExecuteW(NULL, L"open", L"RagnaPH.exe", L"--from-launcher", NULL, SW_SHOWNORMAL);
+    if (hReady) {
+        WaitForSingleObject(hReady, INFINITE);
+        CloseHandle(hReady);
+    }
     return 0;
 }
 
@@ -707,6 +713,13 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         HANDLE hThread = CreateThread(NULL, 0, ProtectionThread, NULL, 0, NULL);
         if (!hThread) return FALSE;
         CloseHandle(hThread);
+
+        // Signal to the launcher that initialization is complete
+        HANDLE hReady = OpenEventW(EVENT_MODIFY_STATE, FALSE, kReadyEventName);
+        if (hReady) {
+            SetEvent(hReady);
+            CloseHandle(hReady);
+        }
     } else if (reason == DLL_PROCESS_DETACH) {
         Gdiplus::GdiplusShutdown(gGdiplusToken);
         if (g_hProgressDone) {


### PR DESCRIPTION
## Summary
- Add named event to coordinate SafePlay readiness with RagnaPH Launcher
- Wait for game to signal SafePlay initialization before launcher exits
- Notify launcher when DLL setup completes in the game process

## Testing
- `dotnet build SafePlay.sln` *(fails: command not found: dotnet)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7165eef0832e9b76cb091989bee0