### PR TITLE
Notify when launcher is hooked

### DIFF
--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -355,6 +355,7 @@ static bool IsLaunchedFromLauncher() {
 DWORD WINAPI ProtectionThread(LPVOID lpParam);
 DWORD WINAPI ShowErrorAndExit(LPVOID lpParam);
 DWORD WINAPI ShowLauncherErrorAndExit(LPVOID);
+DWORD WINAPI ShowHookedNotification(LPVOID);
 const wchar_t* GetDetectedCheatTool(DWORD pid);
 
 // Show an error message and terminate the game
@@ -376,6 +377,15 @@ DWORD WINAPI ShowLauncherErrorAndExit(LPVOID)
         L"Please launch the game via RagnaPH Launcher.exe.",
         L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
     ExitProcess(0);
+    return 0;
+}
+
+// Notify the user when the launcher has been hooked successfully
+DWORD WINAPI ShowHookedNotification(LPVOID)
+{
+    MessageBoxW(NULL,
+        L"SafePlay successfully hooked into RagnaPH Launcher.exe.",
+        L"SafePlay", MB_ICONINFORMATION | MB_TOPMOST | MB_SETFOREGROUND);
     return 0;
 }
 
@@ -672,6 +682,9 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         const wchar_t* processName = PathFindFileNameW(processPath);
         // Handle launcher and game processes separately to avoid accidental self-launching
         if (_wcsicmp(processName, L"RagnaPH Launcher.exe") == 0) {
+            // Notify when hooked into the official launcher
+            HANDLE hNotify = CreateThread(NULL, 0, ShowHookedNotification, NULL, 0, NULL);
+            if (hNotify) CloseHandle(hNotify);
             // When injected into the official launcher, start the game after the popup
             HANDLE hLaunch = CreateThread(NULL, 0, LaunchGameThread, NULL, 0, NULL);
             if (hLaunch) CloseHandle(hLaunch);


### PR DESCRIPTION
## Summary
- show info popup when SafePlay hooks into RagnaPH Launcher.exe
- trigger notification as part of launcher hook logic

## Testing
- `dotnet build SafePlay.sln` *(fails: command not found)*
- `x86_64-w64-mingw32-g++ -std=c++17 -shared -o SafePlay.dll SafePlay/dllmain.cpp` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad798fd098832eb60c11689a66e6ce