### PR TITLE
Add launcher stub and process spawner

### DIFF
--- a/SafePlay.sln
+++ b/SafePlay.sln
@@ -5,6 +5,10 @@ VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SafePlay", "SafePlay\SafePlay.vcxproj", "{B0E7115C-1EBB-498D-80C1-3FD18945D275}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SafePlayExe", "SafePlayExe\SafePlayExe.vcxproj", "{FE86474A-900D-4D3B-8B8E-643DE3FABF27}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sp", "sp\sp.vcxproj", "{C79D695A-507A-4BEA-847F-9209D2FA9C36}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -21,6 +25,22 @@ Global
 		{B0E7115C-1EBB-498D-80C1-3FD18945D275}.Release|x64.Build.0 = Release|x64
 		{B0E7115C-1EBB-498D-80C1-3FD18945D275}.Release|x86.ActiveCfg = Release|Win32
 		{B0E7115C-1EBB-498D-80C1-3FD18945D275}.Release|x86.Build.0 = Release|Win32
+		{FE86474A-900D-4D3B-8B8E-643DE3FABF27}.Debug|x64.ActiveCfg = Release|x64
+		{FE86474A-900D-4D3B-8B8E-643DE3FABF27}.Debug|x64.Build.0 = Release|x64
+		{FE86474A-900D-4D3B-8B8E-643DE3FABF27}.Debug|x86.ActiveCfg = Release|Win32
+		{FE86474A-900D-4D3B-8B8E-643DE3FABF27}.Debug|x86.Build.0 = Release|Win32
+		{FE86474A-900D-4D3B-8B8E-643DE3FABF27}.Release|x64.ActiveCfg = Release|x64
+		{FE86474A-900D-4D3B-8B8E-643DE3FABF27}.Release|x64.Build.0 = Release|x64
+		{FE86474A-900D-4D3B-8B8E-643DE3FABF27}.Release|x86.ActiveCfg = Release|Win32
+		{FE86474A-900D-4D3B-8B8E-643DE3FABF27}.Release|x86.Build.0 = Release|Win32
+		{C79D695A-507A-4BEA-847F-9209D2FA9C36}.Debug|x64.ActiveCfg = Release|x64
+		{C79D695A-507A-4BEA-847F-9209D2FA9C36}.Debug|x64.Build.0 = Release|x64
+		{C79D695A-507A-4BEA-847F-9209D2FA9C36}.Debug|x86.ActiveCfg = Release|Win32
+		{C79D695A-507A-4BEA-847F-9209D2FA9C36}.Debug|x86.Build.0 = Release|Win32
+		{C79D695A-507A-4BEA-847F-9209D2FA9C36}.Release|x64.ActiveCfg = Release|x64
+		{C79D695A-507A-4BEA-847F-9209D2FA9C36}.Release|x64.Build.0 = Release|x64
+		{C79D695A-507A-4BEA-847F-9209D2FA9C36}.Release|x86.ActiveCfg = Release|Win32
+		{C79D695A-507A-4BEA-847F-9209D2FA9C36}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SafePlayExe/SafePlay.cpp
+++ b/SafePlayExe/SafePlay.cpp
@@ -1,0 +1,10 @@
+#include <windows.h>
+
+int APIENTRY WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
+    HMODULE lib = LoadLibraryA("sp.dll");
+    if (!lib) {
+        MessageBoxA(NULL, "Failed to load sp.dll", "SafePlay", MB_OK | MB_ICONERROR);
+        return 1;
+    }
+    return 0;
+}

--- a/SafePlayExe/SafePlayExe.vcxproj
+++ b/SafePlayExe/SafePlayExe.vcxproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{FE86474A-900D-4D3B-8B8E-643DE3FABF27}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>SafePlayExe</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Configuration)\</IntDir>
+    <TargetName>SafePlay</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader />
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="SafePlay.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/sp/sp.cpp
+++ b/sp/sp.cpp
@@ -1,0 +1,22 @@
+#include <windows.h>
+
+static DWORD WINAPI LaunchClient(LPVOID) {
+    STARTUPINFOA si{sizeof(si)};
+    PROCESS_INFORMATION pi{};
+    char cmd[] = "RagnaPH.exe -1sak1";
+    if (!CreateProcessA(NULL, cmd, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) {
+        MessageBoxA(NULL, "Failed to start RagnaPH.exe", "sp.dll", MB_OK | MB_ICONERROR);
+        return 0;
+    }
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    return 0;
+}
+
+BOOL APIENTRY DllMain(HINSTANCE hinst, DWORD reason, LPVOID) {
+    if (reason == DLL_PROCESS_ATTACH) {
+        DisableThreadLibraryCalls(hinst);
+        CreateThread(NULL, 0, LaunchClient, NULL, 0, NULL);
+    }
+    return TRUE;
+}

--- a/sp/sp.vcxproj
+++ b/sp/sp.vcxproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C79D695A-507A-4BEA-847F-9209D2FA9C36}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>sp</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Configuration)\</IntDir>
+    <TargetName>sp</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader />
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="sp.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>


### PR DESCRIPTION
## Summary
- Add minimal `SafePlay.exe` launcher that attempts to load `sp.dll` and shows an error dialog if loading fails.
- Implement `sp.dll` to spawn `RagnaPH.exe -1sak1` on a separate thread, reporting failures via MessageBox.
- Register both new projects in the Visual Studio solution for building.

## Testing
- `x86_64-w64-mingw32-g++ -Wall -O2 -mwindows -o /tmp/SafePlay.exe SafePlayExe/SafePlay.cpp`
- `x86_64-w64-mingw32-g++ -Wall -O2 -mwindows -shared -o /tmp/sp.dll sp/sp.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68ad88fe7d0c832e9cb1613ba7543a11