### PR TITLE
Resolve library paths for SafePlay

### DIFF
--- a/SafePlayExe/SafePlay.cpp
+++ b/SafePlayExe/SafePlay.cpp
@@ -1,7 +1,16 @@
 #include <windows.h>
+#include <shlwapi.h>
+
+#pragma comment(lib, "Shlwapi.lib")
 
 int APIENTRY WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
-    HMODULE lib = LoadLibraryA("sp.dll");
+    char path[MAX_PATH];
+    if (!GetModuleFileNameA(NULL, path, MAX_PATH))
+        return 1;
+    PathRemoveFileSpecA(path);
+    lstrcatA(path, "\\sp.dll");
+
+    HMODULE lib = LoadLibraryA(path);
     if (!lib) {
         MessageBoxA(NULL, "Failed to load sp.dll", "SafePlay", MB_OK | MB_ICONERROR);
         return 1;

--- a/sp/sp.cpp
+++ b/sp/sp.cpp
@@ -1,9 +1,25 @@
 #include <windows.h>
+#include <shlwapi.h>
+
+#pragma comment(lib, "Shlwapi.lib")
+
+static HMODULE gModule;
 
 static DWORD WINAPI LaunchClient(LPVOID) {
+    char base[MAX_PATH];
+    if (!GetModuleFileNameA(gModule, base, MAX_PATH))
+        return 0;
+    PathRemoveFileSpecA(base);
+
+    char exe[MAX_PATH];
+    lstrcpynA(exe, base, MAX_PATH);
+    lstrcatA(exe, "\\RagnaPH.exe");
+
+    char cmd[MAX_PATH * 2];
+    wsprintfA(cmd, "\"%s\" -1sak1", exe);
+
     STARTUPINFOA si{sizeof(si)};
     PROCESS_INFORMATION pi{};
-    char cmd[] = "RagnaPH.exe -1sak1";
     if (!CreateProcessA(NULL, cmd, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) {
         MessageBoxA(NULL, "Failed to start RagnaPH.exe", "sp.dll", MB_OK | MB_ICONERROR);
         return 0;
@@ -15,6 +31,7 @@ static DWORD WINAPI LaunchClient(LPVOID) {
 
 BOOL APIENTRY DllMain(HINSTANCE hinst, DWORD reason, LPVOID) {
     if (reason == DLL_PROCESS_ATTACH) {
+        gModule = hinst;
         DisableThreadLibraryCalls(hinst);
         CreateThread(NULL, 0, LaunchClient, NULL, 0, NULL);
     }


### PR DESCRIPTION
## Summary
- resolve sp.dll location relative to SafePlay.exe
- launch RagnaPH.exe from sp.dll using full path and -1sak1 parameter

## Testing
- `x86_64-w64-mingw32-g++ -shared -o sp.dll sp/sp.cpp -lshlwapi`
- `x86_64-w64-mingw32-g++ -mwindows -o SafePlay.exe SafePlayExe/SafePlay.cpp -lshlwapi`


------
https://chatgpt.com/codex/tasks/task_e_68ad925aab98832ebd5a1ff80b7d9eb5