### PR TITLE
Require SafePlay launcher for game start

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ A companion **SafePlay.exe** launcher is provided to start `RagnaPH.exe` from a 
 * `Data.ini` must have `data.grf` as its first entry – the DLL validates this file before enabling protection.
 * Extend the banned executable, window, module, or memory signature lists in `SafePlay/dllmain.cpp` to detect additional tools.
 
+## Usage
+Run `SafePlay.exe` to launch the game. The launcher sets a special
+environment variable that `SafePlay.dll` checks during startup. If
+`RagnaPH.exe` is executed directly the variable is missing, the DLL
+displays an error, and the game terminates. This ensures the client
+always starts through the protected launcher.
+
 ## Roadmap
 - Cross-game compatibility
 - External configuration file support

--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -569,6 +569,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         g_hModule = hModule;
         DisableThreadLibraryCalls(hModule);
 
+        if (GetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", NULL, 0) == 0) {
+            MessageBoxW(NULL, L"Please start the game using SafePlay.exe", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
+            return FALSE;
+        }
+
         Gdiplus::GdiplusStartupInput gdiplusStartupInput;
         Gdiplus::GdiplusStartup(&gGdiplusToken, &gdiplusStartupInput, NULL);
 

--- a/SafePlayLauncher/main.cpp
+++ b/SafePlayLauncher/main.cpp
@@ -1,6 +1,8 @@
 #include <windows.h>
 
 int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
+    SetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", L"1");
+
     STARTUPINFOW si = { sizeof(si) };
     PROCESS_INFORMATION pi{};
     wchar_t cmd[] = L"RagnaPH.exe";


### PR DESCRIPTION
## Summary
- Set `SAFEPLAY_LAUNCHED` environment variable in the launcher
- Abort if the DLL loads without the environment variable to prevent direct game execution
- Document launcher requirement in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada242e2ec832e8a9b27cffda1d7cf