### PR TITLE
Restrict SafePlay execution to RagnaPH Launcher

### DIFF
--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -570,7 +570,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         DisableThreadLibraryCalls(hModule);
 
         if (GetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", NULL, 0) == 0) {
-            MessageBoxW(NULL, L"Please start the game using SafePlay.exe", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
+            MessageBoxW(NULL, L"Please start the game using RagnaPH Launcher", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
             return FALSE;
         }
 

--- a/SafePlayLauncher/main.cpp
+++ b/SafePlayLauncher/main.cpp
@@ -1,6 +1,51 @@
 #include <windows.h>
+#include <tlhelp32.h>
+#include <cwchar>
+
+static bool LaunchedByRagnaPHLauncher() {
+    DWORD parentId = 0;
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snap == INVALID_HANDLE_VALUE) return false;
+
+    PROCESSENTRY32W pe{};
+    pe.dwSize = sizeof(pe);
+    DWORD selfId = GetCurrentProcessId();
+    if (Process32FirstW(snap, &pe)) {
+        do {
+            if (pe.th32ProcessID == selfId) {
+                parentId = pe.th32ParentProcessID;
+                break;
+            }
+        } while (Process32NextW(snap, &pe));
+    }
+    CloseHandle(snap);
+
+    if (!parentId) return false;
+
+    HANDLE hParent = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, parentId);
+    if (!hParent) return false;
+
+    wchar_t path[MAX_PATH];
+    DWORD size = MAX_PATH;
+    bool ok = false;
+    if (QueryFullProcessImageNameW(hParent, 0, path, &size)) {
+        const wchar_t* fname = wcsrchr(path, L'\\');
+        fname = fname ? fname + 1 : path;
+        if (_wcsicmp(fname, L"RagnaPHLauncher.exe") == 0 ||
+            _wcsicmp(fname, L"RagnaPH Launcher.exe") == 0) {
+            ok = true;
+        }
+    }
+    CloseHandle(hParent);
+    return ok;
+}
 
 int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
+    if (!LaunchedByRagnaPHLauncher()) {
+        MessageBoxW(NULL, L"Please start the game using RagnaPH Launcher", L"SafePlay", MB_OK | MB_ICONERROR);
+        return 1;
+    }
+
     SetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", L"1");
 
     STARTUPINFOW si = { sizeof(si) };


### PR DESCRIPTION
## Summary
- Guard SafePlay.exe against direct execution by verifying it was started by the RagnaPH Launcher.
- Alert users and abort if the DLL is loaded without the launcher.

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68ada56943d0832e8be25d88ca5e13e8