### PR TITLE
Restrict SafePlay launcher to RagnaPH

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 SafePlay is a lightweight Windows DLL designed to keep Ragnarok Online clients and other PC games fair. It injects into the
 game process, provides a trusted client configuration, and continuously scans the system for known cheat tools.
 
-A companion **SafePlay.exe** launcher is provided to start `RagnaPH.exe` from a trusted wrapper.
+A companion **SafePlay.exe** launcher is provided but is intended to be invoked only by the `RagnaPH Launcher` to start `RagnaPH.exe` from a trusted wrapper.
 
 **Target Users:** Game developers, publishers, and server administrators who want to enforce fair play.
 
@@ -44,11 +44,12 @@ A companion **SafePlay.exe** launcher is provided to start `RagnaPH.exe` from a 
 * Extend the banned executable, window, module, or memory signature lists in `SafePlay/dllmain.cpp` to detect additional tools.
 
 ## Usage
-Run `SafePlay.exe` to launch the game. The launcher sets a special
-environment variable that `SafePlay.dll` checks during startup. If
-`RagnaPH.exe` is executed directly the variable is missing, the DLL
-displays an error, and the game terminates. This ensures the client
-always starts through the protected launcher.
+The third-party **RagnaPH Launcher** starts the game by invoking `SafePlay.exe`,
+which sets a special environment variable that `SafePlay.dll` checks during
+startup. Running `SafePlay.exe` directly displays an error and exits. If
+`RagnaPH.exe` is executed without the launcher, the variable is missing, the DLL
+displays an error, and the game terminates. This ensures the client always
+starts through the protected launcher.
 
 ## Roadmap
 - Cross-game compatibility

--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -570,7 +570,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         DisableThreadLibraryCalls(hModule);
 
         if (GetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", NULL, 0) == 0) {
-            MessageBoxW(NULL, L"Please start the game using SafePlay.exe", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
+            MessageBoxW(NULL, L"Please start the game using the RagnaPH Launcher", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
             return FALSE;
         }
 

--- a/SafePlayLauncher/main.cpp
+++ b/SafePlayLauncher/main.cpp
@@ -1,6 +1,46 @@
 #include <windows.h>
+#include <tlhelp32.h>
+
+static bool IsLaunchedByRagnaPHLauncher() {
+    DWORD pid = GetCurrentProcessId();
+    DWORD ppid = 0;
+
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snap == INVALID_HANDLE_VALUE) return false;
+
+    PROCESSENTRY32W pe{ sizeof(pe) };
+    if (Process32FirstW(snap, &pe)) {
+        do {
+            if (pe.th32ProcessID == pid) {
+                ppid = pe.th32ParentProcessID;
+                break;
+            }
+        } while (Process32NextW(snap, &pe));
+    }
+
+    bool ok = false;
+    if (ppid != 0) {
+        pe.dwSize = sizeof(pe);
+        if (Process32FirstW(snap, &pe)) {
+            do {
+                if (pe.th32ProcessID == ppid) {
+                    ok = (_wcsicmp(pe.szExeFile, L"RagnaPH Launcher.exe") == 0);
+                    break;
+                }
+            } while (Process32NextW(snap, &pe));
+        }
+    }
+
+    CloseHandle(snap);
+    return ok;
+}
 
 int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
+    if (!IsLaunchedByRagnaPHLauncher()) {
+        MessageBoxW(NULL, L"Please start the game using the RagnaPH Launcher.", L"SafePlay", MB_OK | MB_ICONERROR);
+        return 1;
+    }
+
     SetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", L"1");
 
     STARTUPINFOW si = { sizeof(si) };


### PR DESCRIPTION
## Summary
- Require SafePlay.exe to be launched by the RagnaPH Launcher before starting the game.
- Update SafePlay.dll startup check to reference the RagnaPH Launcher.
- Document new launch flow in README.

## Testing
- `x86_64-w64-mingw32-g++ SafePlayLauncher/main.cpp -o SafePlayLauncher_test.exe -municode -mwindows`
- `x86_64-w64-mingw32-g++ -std=gnu++17 -c SafePlay/dllmain.cpp -o SafePlay_dllmain.o -municode` *(fails: ‘min’ was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_68ada5695cd0832e83005ae4e996ce82