### PR TITLE
Encode embedded clientinfo in Base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A companion **SafePlay.exe** launcher is provided to start `RagnaPH.exe` from a 
 **Target Users:** Game developers, publishers, and server administrators who want to enforce fair play.
 
 ## How It Works
-* **Embedded configuration** – `clientinfo.xml` is stored in the DLL and is served from memory so the game always connects to
-  the approved server settings.
+* **Embedded configuration** – `clientinfo.xml` is stored Base64-encoded in the DLL and is served from memory so the game
+  always connects to the approved server settings.
 * **Integrity check** – the library verifies that `Data.ini` contains the expected resource listing before starting.
 * **API hooking** – kernel32 file APIs are patched via the Import Address Table to redirect file access to the in-memory
   configuration and to hide the virtual file handle.
@@ -39,7 +39,8 @@ A companion **SafePlay.exe** launcher is provided to start `RagnaPH.exe` from a 
 4. Place `SafePlay.dll` beside your game executable or inject it at runtime.
 
 ## Configuration
-* Modify `SafePlay/clientinfo.h` to change the embedded server address, port, or other client settings.
+* Edit `data/clientinfo.xml` and encode it into `SafePlay/clientinfo.h` (Base64) to change the embedded server address, port,
+  or other client settings.
 * `Data.ini` must have `data.grf` as its first entry – the DLL validates this file before enabling protection.
 * Extend the banned executable, window, module, or memory signature lists in `SafePlay/dllmain.cpp` to detect additional tools.
 

--- a/SafePlay/clientinfo.h
+++ b/SafePlay/clientinfo.h
@@ -1,33 +1,4 @@
 #pragma once
 
-// Embedded clientinfo.xml content loaded virtually
-static const char kClientInfoXml[] = R"(<?xml version="1.0" encoding="euc-kr" ?>
-<clientinfo>
-   <desc>Ragnarok Client Information</desc>
-   <servicetype>korea</servicetype>
-   <servertype>primary</servertype>
-   <connection>
-      <display>RagnaPH</display>
-            <address>server.ragna.ph</address>
-            <port>6901</port>
-            <version>55</version>
-            <langtype>11</langtype>
-<registrationweb>https://ragna.ph/?module=account&action=create</registrationweb>
-<loading>
-<image>loading00.jpg</image>
-<image>loading01.jpg</image>
-<image>loading02.jpg</image>
-<image>loading03.jpg</image>
-<image>loading04.jpg</image>
-</loading>
-<aid>
-            <admin>2000000</admin>
-<admin>2000001</admin>
-<admin>2000002</admin>
-<admin>2000003</admin>
-<admin>2000004</admin>
-<admin>2000005</admin>
-        </aid>
-      </connection>
-</clientinfo>
-)";
+// Base64-encoded clientinfo.xml content loaded virtually
+static const char kClientInfoXmlBase64[] = R"(PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iZXVjLWtyIiA/Pgo8Y2xpZW50aW5mbz4KICAgPGRlc2M+UmFnbmFyb2sgQ2xpZW50IEluZm9ybWF0aW9uPC9kZXNjPgogICA8c2VydmljZXR5cGU+a29yZWE8L3NlcnZpY2V0eXBlPgogICA8c2VydmVydHlwZT5wcmltYXJ5PC9zZXJ2ZXJ0eXBlPgogICA8Y29ubmVjdGlvbj4KICAgICAgPGRpc3BsYXk+UmFnbmFQSDwvZGlzcGxheT4KICAgICAgPGFkZHJlc3M+c2VydmVyLnJhZ25hLnBoPC9hZGRyZXNzPgogICAgICA8cG9ydD42OTAxPC9wb3J0PgogICAgICA8dmVyc2lvbj41NTwvdmVyc2lvbj4KICAgICAgPGxhbmd0eXBlPjExPC9sYW5ndHlwZT4KICAgICAgPHJlZ2lzdHJhdGlvbndlYj5odHRwczovL3JhZ25hLnBoLz9tb2R1bGU9YWNjb3VudCZhY3Rpb249Y3JlYXRlPC9yZWdpc3RyYXRpb253ZWI+CiAgICAgIDxsb2FkaW5nPgogICAgICAgICA8aW1hZ2U+bG9hZGluZzAwLmpwZzwvaW1hZ2U+CiAgICAgICAgIDxpbWFnZT5sb2FkaW5nMDEuanBnPC9pbWFnZT4KICAgICAgICAgPGltYWdlPmxvYWRpbmcwMi5qcGc8L2ltYWdlPgogICAgICAgICA8aW1hZ2U+bG9hZGluZzAzLmpwZzwvaW1hZ2U+CiAgICAgICAgIDxpbWFnZT5sb2FkaW5nMDQuanBnPC9pbWFnZT4KICAgICAgPC9sb2FkaW5nPgogICAgICA8YWlkPgogICAgICAgICA8YWRtaW4+MjAwMDAwMDwvYWRtaW4+CiAgICAgICAgIDxhZG1pbj4yMDAwMDAxPC9hZG1pbj4KICAgICAgICAgPGFkbWluPjIwMDAwMDI8L2FkbWluPgogICAgICAgICA8YWRtaW4+MjAwMDAwMzwvYWRtaW4+CiAgICAgICAgIDxhZG1pbj4yMDAwMDA0PC9hZG1pbj4KICAgICAgICAgPGFkbWluPjIwMDAwMDU8L2FkbWluPgogICAgICA8L2FpZD4KICAgPC9jb25uZWN0aW9uPgo8L2NsaWVudGluZm8+Cg==)";

--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -26,8 +26,28 @@ struct MemoryFile {
     size_t pos;
 };
 
-static MemoryFile gClientInfoFile{ kClientInfoXml, sizeof(kClientInfoXml) - 1, 0 };
+static MemoryFile gClientInfoFile{ nullptr, 0, 0 };
 static HANDLE gClientInfoHandle = (HANDLE)&gClientInfoFile;
+static std::string gClientInfoXml;
+
+static std::string Base64Decode(const std::string& input) {
+    static const std::string chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::vector<int> T(256, -1);
+    for (int i = 0; i < 64; i++) T[chars[i]] = i;
+    std::string out;
+    int val = 0, valb = -8;
+    for (unsigned char c : input) {
+        if (T[c] == -1) break;
+        val = (val << 6) + T[c];
+        valb += 6;
+        if (valb >= 0) {
+            out.push_back(char((val >> valb) & 0xFF));
+            valb -= 8;
+        }
+    }
+    return out;
+}
 
 // Original API pointers
 using CreateFileW_t = HANDLE (WINAPI*)(LPCWSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE);
@@ -239,7 +259,7 @@ struct ClientConfig {
 
 static ClientConfig LoadClientInfoVirtual() {
     ClientConfig cfg{};
-    std::string xml = kClientInfoXml;
+    std::string xml = gClientInfoXml;
     size_t start, end;
     if ((start = xml.find("<address>")) != std::string::npos &&
         (end = xml.find("</address>", start)) != std::string::npos) {
@@ -573,6 +593,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
             MessageBoxW(NULL, L"Please start the game using RagnaPH Launcher", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
             return FALSE;
         }
+
+        gClientInfoXml = Base64Decode(kClientInfoXmlBase64);
+        gClientInfoFile.data = gClientInfoXml.c_str();
+        gClientInfoFile.size = gClientInfoXml.size();
+        gClientInfoFile.pos  = 0;
 
         Gdiplus::GdiplusStartupInput gdiplusStartupInput;
         Gdiplus::GdiplusStartup(&gGdiplusToken, &gdiplusStartupInput, NULL);


### PR DESCRIPTION
## Summary
- Obscure client configuration by storing `clientinfo.xml` as Base64 in `clientinfo.h`
- Decode configuration at runtime before serving the virtual file
- Document Base64 workflow in README

## Testing
- `g++ SafePlay/dllmain.cpp -c -o /tmp/dllmain.o` *(fails: windows.h missing)*
- `x86_64-w64-mingw32-g++ SafePlay/dllmain.cpp -c -o /tmp/dllmain.o` *(fails: 'min' not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6b40a1d0832ea8b19dd2c814c342