### PR TITLE
Handle failure to set SAFEPLAY_LAUNCHED environment variable

### DIFF
--- a/SafePlayLauncher/main.cpp
+++ b/SafePlayLauncher/main.cpp
@@ -46,7 +46,13 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
         return 1;
     }
 
-    SetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", L"1");
+    if (!SetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", L"1")) {
+        DWORD err = GetLastError();
+        wchar_t message[256];
+        swprintf(message, 256, L"Could not prepare protected environment.\n(Error code: %lu)", err);
+        MessageBoxW(NULL, message, L"SafePlay", MB_OK | MB_ICONERROR);
+        return 1;
+    }
 
     STARTUPINFOW si = { sizeof(si) };
     PROCESS_INFORMATION pi{};


### PR DESCRIPTION
## Summary
- stop launching the client if SAFEPLAY_LAUNCHED cannot be written
- surface the Windows error code in an error dialog so the issue can be diagnosed

## Testing
- not run (Windows-only launcher)


------
https://chatgpt.com/codex/tasks/task_e_68dd03f31f2c832eb552a956d5826c02