### PR TITLE
Add SafePlay launcher handshake synchronization

### DIFF
--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -30,6 +30,48 @@ static MemoryFile gClientInfoFile{ nullptr, 0, 0 };
 static HANDLE gClientInfoHandle = (HANDLE)&gClientInfoFile;
 static std::string gClientInfoXml;
 
+static bool IsParentRagnaPHLauncher()
+{
+    DWORD parentId = 0;
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snap == INVALID_HANDLE_VALUE)
+        return false;
+
+    PROCESSENTRY32W pe{};
+    pe.dwSize = sizeof(pe);
+    DWORD selfId = GetCurrentProcessId();
+    if (Process32FirstW(snap, &pe)) {
+        do {
+            if (pe.th32ProcessID == selfId) {
+                parentId = pe.th32ParentProcessID;
+                break;
+            }
+        } while (Process32NextW(snap, &pe));
+    }
+    CloseHandle(snap);
+
+    if (!parentId)
+        return false;
+
+    HANDLE hParent = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, parentId);
+    if (!hParent)
+        return false;
+
+    wchar_t path[MAX_PATH];
+    DWORD size = MAX_PATH;
+    bool trusted = false;
+    if (QueryFullProcessImageNameW(hParent, 0, path, &size)) {
+        const wchar_t* fname = wcsrchr(path, L'\\');
+        fname = fname ? fname + 1 : path;
+        if (_wcsicmp(fname, L"RagnaPHLauncher.exe") == 0 ||
+            _wcsicmp(fname, L"RagnaPH Launcher.exe") == 0) {
+            trusted = true;
+        }
+    }
+    CloseHandle(hParent);
+    return trusted;
+}
+
 static std::string Base64Decode(const std::string& input) {
     static const std::string chars =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -589,8 +631,37 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         g_hModule = hModule;
         DisableThreadLibraryCalls(hModule);
 
+        wchar_t eventName[64];
+        swprintf(eventName, 64, L"SafePlayLaunchReady_%lu", GetCurrentProcessId());
+        HANDLE hLaunchEvent = OpenEventW(EVENT_MODIFY_STATE, FALSE, eventName);
+        if (hLaunchEvent) {
+            OutputDebugStringW(L"SafePlay DLL: Signaling launcher handshake event.\n");
+            SetEvent(hLaunchEvent);
+        }
+
+        bool trustedLaunch = true;
         if (GetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", NULL, 0) == 0) {
-            MessageBoxW(NULL, L"Please start the game using RagnaPH Launcher", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
+            trustedLaunch = false;
+            if (hLaunchEvent) {
+                OutputDebugStringW(L"SafePlay DLL: Trusting session via handshake event despite missing SAFEPLAY_LAUNCHED.\n");
+                trustedLaunch = true;
+            } else if (IsParentRagnaPHLauncher()) {
+                OutputDebugStringW(L"SafePlay DLL: Trusting session via parent-process verification.\n");
+                trustedLaunch = true;
+            } else {
+                MessageBoxW(NULL, L"Please start the game using RagnaPH Launcher", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
+                if (hLaunchEvent) {
+                    CloseHandle(hLaunchEvent);
+                }
+                return FALSE;
+            }
+        }
+
+        if (hLaunchEvent) {
+            CloseHandle(hLaunchEvent);
+        }
+
+        if (!trustedLaunch) {
             return FALSE;
         }
 

--- a/SafePlayLauncher/main.cpp
+++ b/SafePlayLauncher/main.cpp
@@ -63,6 +63,28 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
         return 1;
     }
 
+    wchar_t eventName[64];
+    swprintf(eventName, 64, L"SafePlayLaunchReady_%lu", pi.dwProcessId);
+    HANDLE hLaunchReadyEvent = CreateEventW(NULL, TRUE, FALSE, eventName);
+    if (hLaunchReadyEvent) {
+        const DWORD kLaunchAckTimeoutMs = 15000;
+        DWORD waitResult = WaitForSingleObject(hLaunchReadyEvent, kLaunchAckTimeoutMs);
+        if (waitResult == WAIT_OBJECT_0) {
+            OutputDebugStringW(L"SafePlayLauncher: Launch acknowledgment received.\n");
+        } else if (waitResult == WAIT_TIMEOUT) {
+            OutputDebugStringW(L"SafePlayLauncher: Launch acknowledgment timed out.\n");
+        } else {
+            wchar_t debugMsg[128];
+            swprintf(debugMsg, 128, L"SafePlayLauncher: Launch acknowledgment wait failed (code %lu).\n", GetLastError());
+            OutputDebugStringW(debugMsg);
+        }
+        CloseHandle(hLaunchReadyEvent);
+    } else {
+        wchar_t debugMsg[128];
+        swprintf(debugMsg, 128, L"SafePlayLauncher: Failed to create launch event (code %lu).\n", GetLastError());
+        OutputDebugStringW(debugMsg);
+    }
+
     CloseHandle(pi.hThread);
     CloseHandle(pi.hProcess);
     return 0;


### PR DESCRIPTION
## Summary
- wait for a process-specific handshake event after launching the game so the DLL can acknowledge startup and log the result
- signal the handshake event from the DLL, trust the handshake when SAFEPLAY_LAUNCHED is absent, and fall back to parent-process verification with debug logging

## Testing
- Not run (not applicable on this platform)


------
https://chatgpt.com/codex/tasks/task_e_68dd17795160832e9e13de8fbf95e899