### PR TITLE
Handle SafePlay launcher environment flag before guard

### DIFF
--- a/SafePlay/dllmain.cpp
+++ b/SafePlay/dllmain.cpp
@@ -589,9 +589,19 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         g_hModule = hModule;
         DisableThreadLibraryCalls(hModule);
 
-        if (GetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", NULL, 0) == 0) {
-            MessageBoxW(NULL, L"Please start the game using RagnaPH Launcher", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
-            return FALSE;
+        wchar_t processPath[MAX_PATH] = { 0 };
+        GetModuleFileNameW(NULL, processPath, MAX_PATH);
+        const wchar_t* processName = PathFindFileNameW(processPath);
+        bool isLauncherProcess = (_wcsicmp(processName, L"SafePlay.exe") == 0);
+        bool isGameProcess = (_wcsicmp(processName, L"RagnaPH.exe") == 0);
+
+        if (isLauncherProcess) {
+            SetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", L"1");
+        } else if (isGameProcess) {
+            if (GetEnvironmentVariableW(L"SAFEPLAY_LAUNCHED", NULL, 0) == 0) {
+                MessageBoxW(NULL, L"Please start the game using RagnaPH Launcher", L"SafePlay", MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
+                return FALSE;
+            }
         }
 
         gClientInfoXml = Base64Decode(kClientInfoXmlBase64);
@@ -606,11 +616,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         // Show loading popup without blocking game startup
         HANDLE hPopup = CreateThread(NULL, 0, LoadingPopupThread, NULL, 0, NULL);
 
-        wchar_t processPath[MAX_PATH];
-        GetModuleFileNameW(NULL, processPath, MAX_PATH);
-        const wchar_t* processName = PathFindFileNameW(processPath);
         // Prevent infinite self-launching when the DLL is injected into the game executable itself
-        if (_wcsicmp(processName, L"RagnaPH.exe") != 0) {
+        if (!isGameProcess) {
             HANDLE hLaunch = CreateThread(NULL, 0, LaunchGameThread, NULL, 0, NULL);
             if (hLaunch) CloseHandle(hLaunch);
         }


### PR DESCRIPTION
## Summary
- detect the hosting process before applying the SAFEPLAY_LAUNCHED guard
- mark the launcher process in the environment and retain the direct launch block for the game executable

## Testing
- msbuild SafePlay.sln *(fails: msbuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd324751d4832e852412a30bc9cbdc